### PR TITLE
Fix broken link in email notification by always using the job ID

### DIFF
--- a/cloudgene.hla.yaml
+++ b/cloudgene.hla.yaml
@@ -16,6 +16,7 @@ workflow:
       # params without UI
       params:
         project: "${CLOUDGENE_JOB_NAME}"
+        project_id: "${CLOUDGENE_JOB_ID}"        
         files: "${files}/*.vcf.gz"
         chunksize: 1000000000
         minSamples: 0

--- a/cloudgene.pgs.yaml
+++ b/cloudgene.pgs.yaml
@@ -14,6 +14,7 @@ workflow:
       # params without UI
       params:
         project: "${CLOUDGENE_JOB_NAME}"
+        project_id: "${CLOUDGENE_JOB_ID}"        
         files: "${files}/*.vcf.gz"
         mode: "imputation"
         allele_frequency_population: "off"

--- a/cloudgene.yaml
+++ b/cloudgene.yaml
@@ -14,6 +14,7 @@ workflow:
       # params without UI
       params:
         project: "${CLOUDGENE_JOB_NAME}"
+        project_id: "${CLOUDGENE_JOB_ID}"
         allele_frequency_population: "${population}"
         files: "${files}/*.vcf.gz"
         encryption:

--- a/main.nf
+++ b/main.nf
@@ -178,7 +178,7 @@ workflow.onComplete {
             sendMail{
                 to "${params.user.email}"
                 subject "[${params.service.name}] Job ${params.project} is complete"
-                body "Dear ${params.user.name}, \n Your imputation job has finished succesfully. The password for the imputation results is: ${params.encryption_password}\n\n You can download the results from the following link: ${params.service.url}/index.html#!jobs/${params.project}"
+                body "Dear ${params.user.name}, \n Your imputation job has finished succesfully. The password for the imputation results is: ${params.encryption_password}\n\n You can download the results from the following link: ${params.service.url}/index.html#!jobs/${params.project_id}"
             }
             println "::message:: Data have been exported successfully. We have sent a notification email to <b>${params.user.email}</b>"
         } else {


### PR DESCRIPTION
This PR fixes an issue where email notifications contained a broken link because the URL was not consistently generated with the job ID.