### PR TITLE
Fix fatal S3 error when renaming X chromosome

### DIFF
--- a/workflows/imputation.nf
+++ b/workflows/imputation.nf
@@ -59,6 +59,6 @@ public static String updateChrX(Object value) {
     //update value
     String updadedValue=value.toString().replaceAll('PAR1','1').replaceAll('nonPAR','2').replaceAll('PAR2','3');
     //rename file
-    file(value).renameTo(updadedValue) 
+    file(value).moveTo(updadedValue)
     return updadedValue
 }

--- a/workflows/imputation.nf
+++ b/workflows/imputation.nf
@@ -2,11 +2,11 @@ include { MINIMAC4 } from '../modules/local/imputation/minimac4'
 
 workflow IMPUTATION {
 
-    take: 
-    phased_ch 
+    take:
+    phased_ch
 
     main:
-    if (params.refpanel.mapMinimac == null) { 
+    if (params.refpanel.mapMinimac == null) {
         minimac_map = []
     } else {
         minimac_map = file(params.refpanel.mapMinimac, checkIfExists: true)
@@ -15,20 +15,20 @@ workflow IMPUTATION {
     chromosomes = Channel.of(1..22, 'X.nonPAR', 'X.PAR1', 'X.PAR2', 'MT')
     minimac_m3vcf_ch = chromosomes
         .map {
-            it -> 
+            it ->
                 def genotypes_file = file(PatternUtil.parse(params.refpanel.genotypes, [chr: it]))
                     if(!genotypes_file.exists()){
                         return null;
                     }
-                return tuple(it.toString(),genotypes_file); 
+                return tuple(it.toString(),genotypes_file);
         }
 
     phased_m3vcf_ch = phased_ch.combine(minimac_m3vcf_ch, by: 0)
 
-    MINIMAC4 ( 
-        phased_m3vcf_ch, 
+    MINIMAC4 (
+        phased_m3vcf_ch,
         minimac_map,
-        params.refpanel.build,        
+        params.refpanel.build,
         params.imputation.window,
         params.imputation.minimac_min_ratio,
         params.imputation.min_r2,
@@ -40,24 +40,24 @@ workflow IMPUTATION {
     )
 
     imputed_chunks_modified = MINIMAC4.out.imputed_chunks.
-        map { 
+        map {
             tuple ->
                 if (tuple[0].startsWith('X.')){
                     tuple[0] = 'X'
-                    tuple[3] = updateChrX(tuple[3]) 
-                    tuple[4] = updateChrX(tuple[4]) 
-                    tuple[5] = updateChrX(tuple[5]) 
+                    tuple[3] = updateChrX(tuple[3])
+                    tuple[4] = updateChrX(tuple[4])
+                    tuple[5] = updateChrX(tuple[5])
                 }
                 return tuple
             }
 
-    emit: 
+    emit:
     imputed_chunks = imputed_chunks_modified
 }
 
 public static String updateChrX(Object value) {
     //update value
-    String updadedValue=value.toString().replaceAll('PAR1','1').replaceAll('nonPAR','2').replaceAll('PAR2','3');
+    String updadedValue = value.toString().replaceAll('PAR1','1').replaceAll('nonPAR','2').replaceAll('PAR2','3')
     //rename file
     file(value).moveTo(updadedValue)
     return updadedValue


### PR DESCRIPTION
Fix fatal error when renaming files backed in S3.

The Nextflow built-in `file(...).renameTo(...)`, used in `workflows/imputation.nf` to rename X chromosome files, raises an error when using S3 storage, causing a job failure with the message:
```
ERROR ~ Not a valid S3 file system provider file attribute view: java.nio.file.attribute.PosixFileAttributeView
```
This change uses `file(...).moveTo(...)` instead, which handles S3 storage correctly.

(the underlying issue seems to be a wrong assumption by the `renameTo()` implementation that the filesystem has POSIX-style file access attributes, which is not the case in S3).