### PR TITLE
input_validation: add missing parameters r2Filter and chunksize.

### DIFF
--- a/modules/local/input_validation/input_validation_vcf.nf
+++ b/modules/local/input_validation/input_validation_vcf.nf
@@ -1,13 +1,13 @@
 import groovy.json.JsonOutput
 
 process INPUT_VALIDATION_VCF {
-    
+
     label 'preprocessing'
     publishDir params.output, mode: 'copy', pattern: '*.{html,log}'
 
     input:
     path(vcf_files)
-  
+
     output:
     path("*.vcf.gz"), includeInputs: true, emit: validated_files
     path("validation_report.txt"), emit: validation_report
@@ -43,13 +43,15 @@ process INPUT_VALIDATION_VCF {
         --reference reference-panel.json \
         --build ${params.build} \
         --mode ${params.mode} \
+        --r2Filter ${params.imputation.min_r2} \
+        --chunksize ${params.chunksize} \
         --minSamples ${params.min_samples} \
         --maxSamples ${params.max_samples} \
         --report validation_report.txt \
         --no-index \
         --contactName "${(params.service.contact == "" || params.service.contact == null) ? "Admin" : params.service.contact}" \
         --contactEmail "${(params.service.email == "" || params.service.email == null) ? "admin@localhost" : params.service.email}" \
-        $vcf_files 
+        $vcf_files
     exit_code_a=\$?
 
     cat validation_report.txt


### PR DESCRIPTION
Currently, the input validation command accepts parameters for `r2Filter` and `chunksize`, but these are not passed in as arguments.

It seems to be a relatively minor issue:
* `r2Filter` is only used for conditional display.
* `chunksize` is used for VCF file loading, but the only difference I have observed is the displayed number of chunks (it will be wrong if `chunksize` is different from the default value of 20,000,000).

This change forwards `params.imputation.min_r2` to `r2Filter`, and `params.chunksize` to `chunksize`.