### PR TITLE
Fix email punctuation

### DIFF
--- a/main.nf
+++ b/main.nf
@@ -159,7 +159,7 @@ workflow.onComplete {
                 sendMail{
                     to "${params.user.email}"
                     subject "[${params.service.name}] Job ${params.project} ${statusMessage}" 
-                    body "Dear ${params.user.name}, \n ${statusText}.\n\n More details can be found at the following link: ${params.service.url}/index.html#!jobs/${params.project_id}"
+                    body "Dear ${params.user.name},\n${statusText}\n\nMore details can be found at the following link: ${params.service.url}/index.html#!jobs/${params.project_id}"
                 }
             }
         println "::error:: Imputation job ${statusMessage}." 
@@ -185,7 +185,7 @@ workflow.onComplete {
             sendMail{
                 to "${params.user.email}"
                 subject "[${params.service.name}] Job ${params.project} is complete"
-                body "Dear ${params.user.name}, \n Your imputation job has finished succesfully. The password for the imputation results is: ${params.encryption_password}\n\n You can download the results from the following link: ${params.service.url}/index.html#!jobs/${params.project_id}"
+                body "Dear ${params.user.name},\nYour imputation job has finished succesfully. The password for the imputation results is: ${params.encryption_password}\n\nYou can download the results from the following link: ${params.service.url}/index.html#!jobs/${params.project_id}"
             }
             println "::message:: Data have been exported successfully. We have sent a notification email to <b>${params.user.email}</b>"
         } else {
@@ -199,7 +199,7 @@ workflow.onComplete {
         sendMail{
             to "${params.user.email}"
             subject "[${params.service.name}] Job ${params.project} is complete"
-            body "Dear ${params.user.name}, \n Your PGS job has finished successfully. \n\n You can download the results from the following link: ${params.service.url}/index.html#!jobs/${params.project_id}"
+            body "Dear ${params.user.name},\nYour PGS job has finished successfully.\n\nYou can download the results from the following link: ${params.service.url}/index.html#!jobs/${params.project_id}"
         }
         println "::message:: Data have been exported successfully. We have sent a notification email to <b>${params.user.email}</b>"
     } else {


### PR DESCRIPTION
* Avoid strange email formatting by removing spaces before and after newlines `\n`
* Avoid a double period `..` in error and cancellation emails. This is caused when interpolating `statusText` into the email body.

Here is a current email body showing both problems (note the indentation in all lines but the first, and the two periods after "Your job failed"):
```
Dear marcfra,
 Your job failed..

 More details can be found at the following link: <url redacted>
```