### PR TITLE
Bugfix: close malformed ::group:: tags.

### DIFF
--- a/modules/local/input_validation/input_validation_vcf.nf
+++ b/modules/local/input_validation/input_validation_vcf.nf
@@ -28,7 +28,7 @@ process INPUT_VALIDATION_VCF {
     for vcf in $vcf_files; do
         # Attempt to create the index using tabix
         if ! output=\$(tabix -p vcf "\$vcf" 2>&1); then
-            echo ::group type=error
+            echo ::group type=error::
             echo "The provided VCF file is malformed."
             echo "Error: \$output"
             echo ::endgroup::

--- a/modules/local/quality_control/quality_control_vcf.nf
+++ b/modules/local/quality_control/quality_control_vcf.nf
@@ -1,7 +1,7 @@
 import groovy.json.JsonOutput
 
 process QUALITY_CONTROL_VCF {
-    
+
     label 'preprocessing'
     publishDir params.output, mode: 'copy', pattern: "qc_report.txt"
     publishDir params.output, mode: 'copy', pattern: "${statisticsDir}/*.txt"
@@ -40,14 +40,14 @@ process QUALITY_CONTROL_VCF {
     for vcf in $vcf_files; do
         # Attempt to create the index using tabix
         if ! output=\$(tabix -p vcf "\$vcf" 2>&1); then
-            echo ::group type=error
+            echo ::group type=error::
             echo "The provided VCF file is malformed."
             echo "Error: \$output"
             echo ::endgroup::
             exit 1
         fi
     done
-    
+
     # TODO: create directories in java
     mkdir ${chunksDir}
     mkdir ${metaFilesDir}
@@ -68,7 +68,7 @@ process QUALITY_CONTROL_VCF {
         --report qc_report.txt \
         --no-index \
         $chain \
-        $vcf_files 
+        $vcf_files
 
     exit_code_a=\$?
 
@@ -78,7 +78,7 @@ process QUALITY_CONTROL_VCF {
     fi
 
     cat qc_report.txt
-    
+
     # Always exit 0 that QC files get published
     exit 0
     """


### PR DESCRIPTION
There are two `::group type=error::` tags that are missing the closing double-colon `::` (one in `input_validation_vcf.nf` and one in `quality_control_vcf.nf`). This fix adds them.